### PR TITLE
SSL-35: Fix bugs concerning configure SSL step one

### DIFF
--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepOne.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepOne.php
@@ -118,10 +118,11 @@ class SSLStepOne
             $countriesForGenerateCsrForm,
             ['wildcard' => $wildCard]
         ) : '';
-        //when server type is not selected exception
+
         if (isset($_POST['privateKey']) && $_POST['privateKey'] != null && empty(json_decode($fillVarsJSON))) {
             $autoFillPrivateKeyField = ScriptService::getAutoFillPrivateKeyField($_POST['privateKey']);
         }
+
         //auto fill order type field
         if (isset($_POST['fields']['order_type']) && $_POST['fields']['order_type'] != null) {
             $autoFillOrderTypeField = ScriptService::getAutoFillOrderTypeField($_POST['fields']['order_type']);

--- a/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/generateCsrModal.tpl
+++ b/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/generateCsrModal.tpl
@@ -90,7 +90,6 @@
 
         $("#countryName option[value=\"{$csrData['country']}\"]").attr('selected','');
 
-        $('#modalgenerateCsrSubmit').prop('disabled',true);
         $.urlParam = function(name){
             var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(window.location.href);
             if (results==null){

--- a/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/stepOneBase.tpl
+++ b/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/stepOneBase.tpl
@@ -4,57 +4,48 @@
 
         {if $domains && $auto_install_panel}
 
-            $('#inputCsr').attr('readonly','');
+            const alertInfo = $('.alert-info').first();
+            const csrInput = $('#inputCsr');
+            csrInput.attr('readonly', '');
 
-            $('<div><input style="width: 15px;height: 15px;float: left;" type="checkbox" id="csrReadOnly" /><label for="csrReadOnly" style="font-size: 13px;float: left;margin-top: -20px;margin-left: 20px;">{$ADDONLANG->T('csrReadOnly')}</label></div>').insertBefore("#inputCsr");
+            $('<div><input style="width: 15px;height: 15px;float: left;" type="checkbox" id="csrReadOnly" />' +
+                '<label for="csrReadOnly" style="font-size: 13px;float: left;margin-top: ' +
+                '-20px;margin-left: 20px;">{$ADDONLANG->T('csrReadOnly')}</label></div>').insertBefore(csrInput);
 
-            $('body').on('change','#csrReadOnly',function (){
-                if(this.checked)
-                {
-                    $('#inputCsr').removeAttr('readonly');
-                }
-                else
-                {
-                    $('#inputCsr').attr('readonly','');
+            $('#csrReadOnly').on('change', e => {
+                if (e.target.checked) {
+                    csrInput.removeAttr('readonly');
+                } else {
+                    csrInput.attr('readonly', '');
                 }
             });
 
-            if(!$('.primary-content .card-body .alert-danger').length) {
+            alertInfo.after('<div class="card-body select-cpanel-server">' +
+                '<h2>{$ADDONLANG->T('Choose a domain')}</h2>' +
+                '<select id="step-type-data">' +
+                '<option value="custom">{$ADDONLANG->T('Custom domain')}</option>' +
+                '</select>' +
+                '<div style="margin-top: 20px;" class="form-group">' +
+                '</div>');
+            alertInfo.hide();
 
-                const contentPage = $('#inputCsr').parent('div.form-group');
+            {foreach $domains as $domain}
+                $('#step-type-data').append('<option value="{$domain}">{$domain}</option>');
+            {/foreach}
 
-                $(contentPage).hide();
-                $(contentPage).parent('div').next("div").hide();
-                $('.alert-info').after('<div class="card-body select-cpanel-server">' +
-                    '<h2>{$ADDONLANG->T('Choose a domain')}</h2>' +
-                    '<select id="step-type-data">' +
-                    '<option value="custom">{$ADDONLANG->T('Custom domain')}</option>' +
-                    '<optgroup label="Server">' +
-                    '</optgroup>' +
-                    '</select>' +
-                    '<div style="margin-top: 20px;" class="form-group"><button id="goto_next_step" class="btn btn-primary" type="button">{$ADDONLANG->T('Next')}</button></div>' +
-                    '</div>');
+            $('#step-type-data').on('change', (e) => {
+                $('input[name="CN"]').val(e.target.value);
+            })
 
-                {foreach $domains as $domain}
-                    $('#step-type-data optgroup').append('<option value="{$domain}">{$domain}</option>');
-                {/foreach}
-
-                $('body').on('click', '#goto_next_step', function () {
-                    $('.select-cpanel-server').hide();
-                    $('input[name="CN"]').val($('#step-type-data').val());
-                    $(contentPage).show();
-                });
-            } else {
-                $('#inputCsr').parent('div').hide();
-            }
         {/if}
 
-        $('.alert-info').hide();
-        var brand = JSON.parse('{$brand}');
-        $('textarea[name="csr"]').closest('.form-group').after('<input class="form-control" type="hidden" name="sslbrand" value="' + brand + '" />');
 
-        var element = $('#divhideme').closest('.form-group');
-        //for control template       
+        const brand = JSON.parse('{$brand}');
+        $('textarea[name="csr"]').closest('.form-group')
+            .after('<input class="form-control" type="hidden" name="sslbrand" value="' + brand + '" />');
+
+        const element = $('#divhideme').closest('.form-group');
+        //for control template
         if (element.parent()[0].className === 'panel-body') {
             element.parent().closest('.panel').remove();
         }
@@ -66,26 +57,25 @@
         $('input, textarea, select').addClass('form-control');
 
         //remove (Required if Organization Name is set) comment
-        var jobTitleInput = $('input[name="jobtitle"]');
-        var jobTitleLabel = jobTitleInput.parent().find('label');//for simplicity template
-        
-        jobTitleInput.parent().html(jobTitleInput);        
+        const jobTitleInput = $('input[name="jobtitle"]');
+        const jobTitleLabel = jobTitleInput.parent().find('label');//for simplicity template
+
+        jobTitleInput.parent().html(jobTitleInput);
         //for simplicity template
-        if(jobTitleInput.parent().find('label').length === 0) {            
-            //$( "p:contains('SANs')").remove();
+        if (jobTitleInput.parent().find('label').length === 0) {
             jobTitleInput.before(jobTitleLabel);
         }
-        if($('textarea[name="fields[sans_domains]"]').length > 1) {
+
+        if ($('textarea[name="fields[sans_domains]"]').length > 1) {
             $('label[for="inputAdditionalField"]')[1].remove();
             $('textarea[name="fields[sans_domains]"]')[1].remove();
-        } 
-        if($('input[name="fields[org_regions]"]').length > 1) {
+        }
+        if ($('input[name="fields[org_regions]"]').length > 1) {
             $('input[name="fields[org_regions]"]')[1].remove();
         }
 
-        $('label[for="inputAdditionalField"]').each(function( index ) {
-            if($(this).text() == '')
-            {
+        $('label[for="inputAdditionalField"]').each(function (index) {
+            if ($(this).text() === '') {
                 $(this).parent('.row').parent('fieldset').remove();
             }
         });


### PR DESCRIPTION
I have also removed the confusing 'Next' button when selecting a domain is an option. Concerning the 500 that is returned when you use an empty csr, that should be fixed on the next OTE deploy in our API

Related issues

#35 
#36 