### PR TITLE
SSL-39: autofill org fields

### DIFF
--- a/modules/addons/realtimeregister_ssl/controllers/addon/admin/ApiConfiguration.php
+++ b/modules/addons/realtimeregister_ssl/controllers/addon/admin/ApiConfiguration.php
@@ -204,36 +204,13 @@ class ApiConfiguration extends AbstractController
         $field->colWidth = 3;
         $field->continue = true;
 
-        $field = new SelectField();
-        $field->disabled = $input['display_csr_generator'] ? false : true;
-        $field->name = 'default_csr_generator_country';
-        $field->required = true;
-        $field->value = $input['default_csr_generator_country'];
-        $field->translateOptions = false;
-        $field->inline = true;
-        $field->colWidth = 5;
-        $field->continue = false;
-        $field->enableDescription = true;
-        $field->options = Countries::getInstance()->getCountriesForAddonDropdown();
-        $field->error = $this->getFieldError('default_csr_generator_country');
-        $form->addField($field);
-
-        $field = new CheckboxField();
-        $field->name = 'profile_data_csr';
-        $field->options = ['profileDataCsr'];
-        $field->value = $input['profile_data_csr'] ? ['profileDataCsr'] : [''];
-        $form->addField($field);
-        $field->inline = true;
-        $field->colWidth = 3;
-        $field->continue = true;
-
         $field = new CheckboxField();
         $field->name = 'auto_install_panel';
         $field->options = ['autoInstallPanel'];
         $field->value = $input['auto_install_panel'] ? ['autoInstallPanel'] : [''];
         $form->addField($field);
         $field->inline = true;
-        $field->colWidth = 5;
+        $field->colWidth = 3;
         $field->continue = true;
 
         $field = new LegendField();

--- a/modules/addons/realtimeregister_ssl/eRepository/RealtimeRegisterSsl/Organization.php
+++ b/modules/addons/realtimeregister_ssl/eRepository/RealtimeRegisterSsl/Organization.php
@@ -65,7 +65,7 @@ class Organization
             'Description'  => '',
             'Required'     => false
         ];
-        $org['org_regions']       = [
+        $org['org_region']       = [
             'FriendlyName' => Lang::getInstance()->T('confOrganizationStateRegion'),
             'Type'         => 'text',
             'Size'         => '30',

--- a/modules/addons/realtimeregister_ssl/eRepository/whmcs/config/Countries.php
+++ b/modules/addons/realtimeregister_ssl/eRepository/whmcs/config/Countries.php
@@ -72,7 +72,7 @@ class Countries
         throw new Exception('Can not match country code to country name');
     }
     
-    public function getCountriesForWhmcsDropdownOptions(string $default = '')
+    public function getCountriesForWhmcsDropdownOptions()
     {
         return implode(',', $this->countries);
     }

--- a/modules/addons/realtimeregister_ssl/eRepository/whmcs/config/Countries.php
+++ b/modules/addons/realtimeregister_ssl/eRepository/whmcs/config/Countries.php
@@ -56,8 +56,23 @@ class Countries
         }
         throw new Exception('Can not match country name to country code');
     }
+
+    /**
+     *
+     * @throws Exception
+     */
+    public function getCountryNameByCode(string $code): string
+    {
+        $code = strtoupper($code);
+
+        if (isset($this->countries[$code])) {
+            return $this->countries[$code];
+        }
+
+        throw new Exception('Can not match country code to country name');
+    }
     
-    public function getCountriesForWhmcsDropdownOptions()
+    public function getCountriesForWhmcsDropdownOptions(string $default = '')
     {
         return implode(',', $this->countries);
     }

--- a/modules/addons/realtimeregister_ssl/eServices/ScriptService.php
+++ b/modules/addons/realtimeregister_ssl/eServices/ScriptService.php
@@ -46,31 +46,25 @@ class ScriptService
         $countriesForGenerateCsrForm,
         $vars = []
     ) {
-        $apiConf = (new Repository())->get();
-        $profile_data_csr = $apiConf->profile_data_csr;
 
-        $csrWithData = false;
         $csrData = [];
-        if ($profile_data_csr) {
-            $service = new Service($serviceId);
-            $client = new Client($service->clientID);
+        $service = new Service($serviceId);
+        $client = new Client($service->clientID);
 
-            $csrData['country'] = $client->getCountry();
-            $csrData['state'] = $client->getState();
-            $csrData['locality'] = $client->getCity();
-            $csrData['organization'] = $client->companyname ?: $client->getFullName();
-            $csrData['org_unit'] = 'IT';
-            $csrData['common_name'] = $service->domain;
-            $csrData['email'] = $client->email;
+        $csrData['country'] = $client->getCountry();
+        $csrData['state'] = $client->getState();
+        $csrData['locality'] = $client->getCity();
+        $csrData['organization'] = $client->companyname ?: $client->getFullName();
+        $csrData['org_unit'] = '';
+        $csrData['common_name'] = $service->domain;
+        $csrData['email'] = $client->email;
 
-            $csrWithData = true;
-        }
 
         return TemplateService::buildTemplate(self::GENERATE_CSR_MODAL, [
             'fillVars' => addslashes($fillVarsJSON),
             'countries'=> json_encode($countriesForGenerateCsrForm),
             'vars' => $vars,
-            'csrWithData' => $csrWithData,
+            'csrWithData' => true,
             'csrData' => $csrData
         ]);
     }

--- a/modules/addons/realtimeregister_ssl/eServices/TemplateService.php
+++ b/modules/addons/realtimeregister_ssl/eServices/TemplateService.php
@@ -2,15 +2,15 @@
 
 namespace AddonModule\RealtimeRegisterSsl\eServices;
 
+use AddonModule\RealtimeRegisterSsl\Addon;
+use AddonModule\RealtimeRegisterSsl\addonLibs\Smarty;
+
 class TemplateService
 {
     public static function buildTemplate($template, array $vars = [])
     {
-        \AddonModule\RealtimeRegisterSsl\Addon::I(true);
-        $dir = \AddonModule\RealtimeRegisterSsl\Addon::getModuleTemplatesDir();
-        return \AddonModule\RealtimeRegisterSsl\addonLibs\Smarty::I()->view($dir . '/' . $template, $vars);
-        $path = $dir . '/' . $template;
-        $path = str_replace('\\', '/', $path);
-        return \AddonModule\RealtimeRegisterSsl\addonLibs\Smarty::I()->view($path, $vars);
+        Addon::I(true);
+        $dir = Addon::getModuleTemplatesDir();
+        return Smarty::I()->view($dir . '/' . $template, $vars);
     }
 }

--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepOne.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepOne.php
@@ -81,24 +81,6 @@ class SSLStepOne
             );
         }
         $countriesForGenerateCsrForm = Countries::getInstance()->getCountriesForAddonDropdown();
-
-        //get selected default country for CSR Generator
-        $defaultCsrGeneratorCountry = ($displayCsrGenerator) ? $apiConf->default_csr_generator_country : '';
-        if (
-            key_exists($defaultCsrGeneratorCountry, $countriesForGenerateCsrForm)
-            && $defaultCsrGeneratorCountry != null
-        ) {
-            //get country name
-            $elementValue = $countriesForGenerateCsrForm[$defaultCsrGeneratorCountry]/* . ' (default)'*/
-            ;
-            //remove country from list
-            unset($countriesForGenerateCsrForm[$defaultCsrGeneratorCountry]);
-            //insert default country on the begin of countries list
-            $countriesForGenerateCsrForm = array_merge(
-                [$defaultCsrGeneratorCountry => $elementValue], $countriesForGenerateCsrForm
-            );
-        }
-
         $wildCard = false;
         $apiProducts = Products::getInstance()->getAllProducts();
         if (

--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
@@ -265,7 +265,7 @@ class SSLStepTwo
             'org_city',
             'org_country',
             'org_postalcode',
-            'org_regions'
+            'org_region'
         ];
 
         foreach ($baseFields as $value) {

--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
@@ -273,11 +273,7 @@ class SSLStepTwo
         }
 
         foreach ($additional as $value) {
-            if ($value == 'fields[order_type]') {
-                $fields[$value] = $this->p['fields']['order_type'];
-            } else {
-                $fields[sprintf('fields[%s]', $value)] = $this->p[$value];
-            }
+            $fields[sprintf('fields[%s]', $value)] = $this->p[$value];
         }
 
         FlashService::setFieldsMemory($_GET['cert'], $fields);

--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
@@ -269,23 +269,14 @@ class SSLStepTwo
         ];
 
         foreach ($baseFields as $value) {
-            $fields[] = [
-                'name' => $value,
-                'value' => $this->p[$value]
-            ];
+            $fields[$value] = $this->p[$value];
         }
 
         foreach ($additional as $value) {
             if ($value == 'fields[order_type]') {
-                $fields[] = [
-                    'name' => sprintf('%s', $value),
-                    'value' => $this->p['fields']['order_type']
-                ];
+                $fields[$value] = $this->p['fields']['order_type'];
             } else {
-                $fields[] = [
-                    'name' => sprintf('fields[%s]', $value),
-                    'value' => $this->p['fields'][$value]
-                ];
+                $fields[sprintf('fields[%s]', $value)] = $this->p[$value];
             }
         }
 

--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLUtils.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLUtils.php
@@ -71,7 +71,7 @@ trait SSLUtils
         $orgMapping = [
             'organization' => 'org_name',
             'country' => 'org_country',
-            'state' => 'org_regions',
+            'state' => 'org_region',
             'address' => 'org_addressline1',
             'postalCode' => 'org_postalcode',
             'city' => 'org_city',

--- a/modules/addons/realtimeregister_ssl/langs/danish.php
+++ b/modules/addons/realtimeregister_ssl/langs/danish.php
@@ -49,7 +49,7 @@ $_LANG['addonAA']['apiConfiguration']['item']['tech_legend']['label']           
 $_LANG['addonAA']['apiConfiguration']['item']['csr_generator_legend']['label']                         = 'CSR Generator';
 $_LANG['addonAA']['apiConfiguration']['item']['display_csr_generator']['label']                        = 'Tillad brugen af CSR Generator';
 $_LANG['addonAA']['apiConfiguration']['item']['profile_data_csr']['label']                             = 'Use Profile Data for CSR';
-$_LANG['addonAA']['apiConfiguration']['item']['auto_install_panel']['']['autoInstallPanel']          = 'Tick this box if you want to use automatic certificate installation';
+$_LANG['addonAA']['apiConfiguration']['item']['auto_install_panel']['']['autoInstallPanel']            = 'Automatic certificate installation';
 $_LANG['addonAA']['apiConfiguration']['item']['default_csr_generator_country']['description']          = 'Standardvalget';
 $_LANG['addonAA']['apiConfiguration']['item']['display_ca_summary']['label']                           = 'Vis Ordreoversigt';
 $_LANG['addonAA']['apiConfiguration']['item']['client_area_summary_orders']['label']                   = 'Klientområde Ordreoversigt';

--- a/modules/addons/realtimeregister_ssl/langs/english.php
+++ b/modules/addons/realtimeregister_ssl/langs/english.php
@@ -47,7 +47,7 @@ $_LANG['addonAA']['apiConfiguration']['item']['tech_legend']['label']           
 $_LANG['addonAA']['apiConfiguration']['item']['csr_generator_legend']['label']                         = 'CSR Generator';
 $_LANG['addonAA']['apiConfiguration']['item']['display_csr_generator']['label']                        = 'Allow To Use CSR Generator';
 $_LANG['addonAA']['apiConfiguration']['item']['profile_data_csr']['label']                             = 'Use Profile Data for CSR';
-$_LANG['addonAA']['apiConfiguration']['item']['auto_install_panel']['']['autoInstallPanel']          = 'Tick this box if you want to use automatic certificate installation';
+$_LANG['addonAA']['apiConfiguration']['item']['auto_install_panel']['']['autoInstallPanel']         = 'Automatic certificate installation';
 $_LANG['addonAA']['apiConfiguration']['item']['default_csr_generator_country']['description']          = 'The default selection';
 $_LANG['addonAA']['apiConfiguration']['item']['display_ca_summary']['label']                           = 'Display Orders Summary';
 $_LANG['addonAA']['apiConfiguration']['item']['client_area_summary_orders']['label']                   = 'Client Area Orders Summary';

--- a/modules/addons/realtimeregister_ssl/langs/german.php
+++ b/modules/addons/realtimeregister_ssl/langs/german.php
@@ -49,7 +49,7 @@ $_LANG['addonAA']['apiConfiguration']['item']['tech_legend']['label']           
 $_LANG['addonAA']['apiConfiguration']['item']['csr_generator_legend']['label']                         = 'CSR-Generator';
 $_LANG['addonAA']['apiConfiguration']['item']['display_csr_generator']['label']                        = 'Verwendung des CSR-Generators zulassen';
 $_LANG['addonAA']['apiConfiguration']['item']['profile_data_csr']['label']                             = 'Use Profile Data for CSR';
-$_LANG['addonAA']['apiConfiguration']['item']['auto_install_panel']['']['autoInstallPanel']          = 'Tick this box if you want to use automatic certificate installation';
+$_LANG['addonAA']['apiConfiguration']['item']['auto_install_panel']['']['autoInstallPanel']          = 'Automatic certificate installation';
 $_LANG['addonAA']['apiConfiguration']['item']['default_csr_generator_country']['description']          = 'Die Standardauswahl';
 $_LANG['addonAA']['apiConfiguration']['item']['display_ca_summary']['label']                           = 'Auftragsübersicht anzeigen';
 $_LANG['addonAA']['apiConfiguration']['item']['client_area_summary_orders']['label']                   = 'Zusammenfassung der Kundenbereichsbestellungen';

--- a/modules/addons/realtimeregister_ssl/models/apiConfiguration/Repository.php
+++ b/modules/addons/realtimeregister_ssl/models/apiConfiguration/Repository.php
@@ -121,7 +121,6 @@ class Repository extends \AddonModule\RealtimeRegisterSsl\addonLibs\models\Repos
                 $table->boolean('api_test');
                 $table->boolean('use_admin_contact');
                 $table->boolean('display_csr_generator');
-                $table->boolean('profile_data_csr');
                 $table->boolean('auto_install_panel');
                 $table->boolean('auto_renew_invoice_one_time');
                 $table->boolean('auto_renew_invoice_reccuring');
@@ -145,7 +144,6 @@ class Repository extends \AddonModule\RealtimeRegisterSsl\addonLibs\models\Repos
                 $table->string('tech_region');
                 $table->string('renew_invoice_days_reccuring')->nullable();
                 $table->string('renew_invoice_days_one_time')->nullable();
-                $table->string('default_csr_generator_country')->nullable();
                 $table->string('summary_expires_soon_days')->nullable();
                 $table->integer('send_certificate_template')->nullable();
                 $table->boolean('display_ca_summary');
@@ -210,11 +208,6 @@ class Repository extends \AddonModule\RealtimeRegisterSsl\addonLibs\models\Repos
                     $table->string('renew_invoice_days_one_time')->nullable();
                 });
             }
-            if (!Capsule::schema()->hasColumn($this->tableName, 'default_csr_generator_country')) {
-                Capsule::schema()->table($this->tableName, function($table) {
-                    $table->string('default_csr_generator_country')->nullable();
-                });
-            }
             if (!Capsule::schema()->hasColumn($this->tableName, 'summary_expires_soon_days')) {
                 Capsule::schema()->table($this->tableName, function($table) {
                     $table->string('summary_expires_soon_days')->nullable();
@@ -248,11 +241,6 @@ class Repository extends \AddonModule\RealtimeRegisterSsl\addonLibs\models\Repos
             if (!Capsule::schema()->hasColumn($this->tableName, 'disable_email_validation')) {
                 Capsule::schema()->table($this->tableName, function($table) {
                     $table->boolean('disable_email_validation');
-                });
-            }
-            if (!Capsule::schema()->hasColumn($this->tableName, 'profile_data_csr')) {
-                Capsule::schema()->table($this->tableName, function($table) {
-                    $table->boolean('profile_data_csr');
                 });
             }
             if (!Capsule::schema()->hasColumn($this->tableName, 'auto_install_panel')) {

--- a/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/autoFill.tpl
+++ b/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/autoFill.tpl
@@ -1,10 +1,9 @@
 <script type="text/javascript">
     $(document).ready(function () {
-        var fillVars = JSON.parse('{$fillVars}');
-        for (var i = 0; i < fillVars.length; i++) {
-            $('input[name="' + fillVars[i].name + '"]').val(fillVars[i].value);
-            $('textarea[name="' + fillVars[i].name + '"]').val(fillVars[i].value);
-            $('select[name="' + fillVars[i].name + '"]').val(fillVars[i].value);
+        for (const [key,value] of Object.entries(JSON.parse('{$fillVars}'))) {
+            $('input[name="' + key + '"]').val(value);
+            $('textarea[name="' + key + '"]').val(value);
+            $('select[name="' + key + '"]').val(value);
         }
     });
 </script>

--- a/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/stepOneBase.tpl
+++ b/modules/addons/realtimeregister_ssl/templates/clientarea/default/scripts/stepOneBase.tpl
@@ -70,8 +70,8 @@
             $('label[for="inputAdditionalField"]')[1].remove();
             $('textarea[name="fields[sans_domains]"]')[1].remove();
         }
-        if ($('input[name="fields[org_regions]"]').length > 1) {
-            $('input[name="fields[org_regions]"]')[1].remove();
+        if ($('input[name="fields[org_region]"]').length > 1) {
+            $('input[name="fields[org_region]"]')[1].remove();
         }
 
         $('label[for="inputAdditionalField"]').each(function (index) {


### PR DESCRIPTION
I also removed some config settings which seem rather useless to me. The default country for the csr generator should be whatever the country of the user is. And profile data as default seems logical to me to be always on, you can always change whatever field you want in the generator

#39