### PR TITLE
fix array key for wildcard commonName check

### DIFF
--- a/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
+++ b/modules/addons/realtimeregister_ssl/eServices/provisioning/SSLStepTwo.php
@@ -189,7 +189,7 @@ class SSLStepTwo
         }
 
         if ($productssl['certificateType'] === 'WILDCARD') {
-            if (str_contains($decodedCSR['csrResult']['CN'], '*.')) {
+            if (str_contains($decodedCSR['commonName'], '*.')) {
                 return true;
             } else {
                 if (isset($decodedCSR['csrResult']['errorMessage'])) {


### PR DESCRIPTION
I got an error like "Invalid CSR" when try to configure wildcard ssl order.
After this code line change, everything works.